### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,19 @@
-FROM tiangolo/meinheld-gunicorn-flask:python3.8
+FROM tiangolo/meinheld-gunicorn-flask:python3.8-alpine3.11
 
-RUN pip install pipenv
+RUN apk add --update-cache \
+    zlib-dev \
+    jpeg-dev \
+    gcc \
+    musl-dev \
+&& rm -rf /var/cache/apk/* \
+&& pip install Pillow==8.0.1 \
+&& apk del \
+    zlib-dev \
+    jpeg-dev \
+    gcc \
+    musl-dev
+
+RUN pip install -U pip pipenv
 
 COPY Pipfile Pipfile.lock ./
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 wtforms = "*"
-pillow = "*"
+pillow = "8.0.1"
 flask-bootstrap = "*"
 flask-wtf = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a825c1cb240457edcec5acc8e1bcb9733e74d5a04f5916e09e159ca5542b2b43"
+            "sha256": "f758ba1e36da7b941e271efa48b038dd56c32fe95c2722915d66756895158211"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -229,11 +229,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
+                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4"
+            "version": "==20.7"
         },
         "pathspec": {
             "hashes": [
@@ -335,14 +335,6 @@
                 "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"
             ],
             "version": "==2020.11.13"
-        },
-        "six": {
-            "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.15.0"
         },
         "toml": {
             "hashes": [


### PR DESCRIPTION
* Use `tiangolo/meinheld-gunicorn-flask:python3.8-alpine3.11` instead of `tiangolo/meinheld-gunicorn-flask:python3.8`
* Image size reduced from `999 MB` to `224 MB`
* Locked Pillow to `8.0.1` to prevent issues in the future, since it is installed outside `pipenv` for docker caching optimizations